### PR TITLE
Fix fifo existence check

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -29,7 +29,7 @@ ssh-keyscan -p $SFTP_PORT $SFTP_HOST > ~/.ssh/known_hosts
 # store backup url
 echo BACKUP_URL=sftp://$SFTP_USER:$SFTP_PASSWORD@$SFTP_HOST:$SFTP_PORT/$BACKUP_NAME > /etc/backup
 
-if ! [ -f /opt/fifo ]; then
+if ! [ -e /opt/fifo ]; then
 	mkfifo /opt/fifo
 fi
 # trigger 'tail -f' to open fifo


### PR DESCRIPTION
Backup container currently fails on restart:
`mkfifo: cannot create fifo '/opt/fifo': File exists`

Modify test as `test -f` explicitly tests for regular files only.

https://github.com/IDgis/PlanoView2/issues/626